### PR TITLE
backuptool: Unmount v3 partitions during backup

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -171,6 +171,7 @@ case "$1" in
       mkdir -p $C
       preserve_addon_d
       run_stages pre-backup backup post-backup
+      umount_extra $all_V3_partitions
     fi
     unmount_system
   ;;

--- a/prebuilt/common/bin/backuptool_ab.sh
+++ b/prebuilt/common/bin/backuptool_ab.sh
@@ -177,6 +177,7 @@ case "$1" in
       mkdir -p $C
       preserve_addon_d
       run_stages pre-backup backup post-backup
+      umount_extra $all_V3_partitions
     else
       cleanup
     fi


### PR DESCRIPTION
Extracted file /tmp/install/bin/backuptool.functions Extracted file /tmp/install/bin/backuptool.sh
Extracted 2 file(s)
about to run program [/tmp/install/bin/backuptool.sh] with 5 args [libfs_mgr]Unmapped logical partition system
DM_DEV_REMOVE failed for [vendor]: Device or resource busy Cannot unmap vendor before removing group qti_dynamic_partitions. script aborted: assert failed: update_dynamic_partitions(package_extract_file(dynamic_partitions_op_list)) assert failed: update_dynamic_partitions(package_extract_file(dynamic_partitions_op_list))error: 25 Updater process ended with ERROR: 1
Failed to mount '/system_root' (No such file or directory) I:Actual block device: '/dev/block/dm-0', current file system: 'ext4'

For curious cats: https://nekobin.com/zejojetoma


Change-Id: Ic2d4e7809e8abd402c2a49188c73c83ea3b4e8df